### PR TITLE
feat: example NH side menu

### DIFF
--- a/tic-tac-toe/ui/components/nh/pageWrapper/PageWrapper.tsx
+++ b/tic-tac-toe/ui/components/nh/pageWrapper/PageWrapper.tsx
@@ -1,14 +1,36 @@
+import Head from "next/head";
+import { ReactNode } from "react";
 import Navigation from "../navigation/Navigation";
+import { SideNavigation } from "../sideNavigation/SideNavigation";
 
-export default function PageWrapper() {
+interface PageWrapperProps {
+  currentPage: string;
+  title: String;
+  children: ReactNode;
+}
+
+export default function PageWrapper({
+  currentPage,
+  title,
+  children,
+}: PageWrapperProps) {
   return (
-    <div className="flex flex-col w-screen bg-nh-bglight items-center min-h-screen py-8">
-      <div className="w-full max-w-nh">
-        <Navigation />
+    <>
+      <Head>
+        <title>{title}</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <div className="flex flex-col w-screen bg-nh-bglight items-center min-h-screen py-8">
+        <div className="w-full max-w-nh">
+          <Navigation />
+        </div>
+        <div className="w-full max-w-nh flex">
+          <div className="w-1/4">
+            <SideNavigation menuPage={currentPage} />
+          </div>
+          <div className="w-3/4">{children}</div>
+        </div>
       </div>
-      <div className="w-3/4 h-full max-w-nh-content-width bg-green-500">
-        {/*TO DO CONTENT WRAPPER */}
-      </div>
-    </div>
+    </>
   );
 }

--- a/tic-tac-toe/ui/components/nh/pageWrapper/getNavigationMap.ts
+++ b/tic-tac-toe/ui/components/nh/pageWrapper/getNavigationMap.ts
@@ -1,0 +1,25 @@
+import { ClockIcon, LightningBoltIcon, PlayIcon } from "@heroicons/react/outline";
+import translation from "../../../constants/en.global.json";
+
+const navigationObject = translation.navigation;
+
+export function getNavigationMap() {
+  const navigation = [
+    {
+      name: navigationObject.dashboardTitle,
+      href: "/",
+      icon: PlayIcon,
+    },
+     {
+      name: navigationObject.currentGamesTitle,
+      href: "/current-games",
+      icon: LightningBoltIcon,
+    },
+     {
+      name: navigationObject.pastGamesTitle,
+      href: "/past-games",
+      icon: ClockIcon,
+    },
+  ];
+  return navigation;
+}

--- a/tic-tac-toe/ui/components/nh/sideNavigation/SideNavigation.tsx
+++ b/tic-tac-toe/ui/components/nh/sideNavigation/SideNavigation.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { getNavigationMap } from "../pageWrapper/getNavigationMap";
+
+interface SideNavigationProps {
+  menuPage: string;
+}
+
+export function SideNavigation({ menuPage }: SideNavigationProps) {
+  return (
+    <div className="hover:text-white text-inter font-medium text-sm">
+      <div className="h-full bg-nh-bglight flex-col">
+        <div className="pl-4 pt-8">
+          {getNavigationMap().map((item, i) => (
+            <div key={i}>
+              <Link href={item.href}>
+                <div
+                  className={`transition duration-700 flex items-center justify-start py-4
+                  ${
+                    item.href === menuPage
+                      ? "text-white"
+                      : "text-nh-navigation-text"
+                  }
+                  hover:text-white cursor-pointer`}
+                >
+                  <item.icon className="w-6 h-6 mr-3" />
+                  <span>{item.name}</span>
+                </div>
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tic-tac-toe/ui/constants/en.global.json
+++ b/tic-tac-toe/ui/constants/en.global.json
@@ -1,0 +1,7 @@
+{
+    "navigation": {
+        "dashboardTitle": "Start New Game",
+        "currentGamesTitle": "Current Games",
+        "pastGamesTitle": "Past Games"
+    }
+}

--- a/tic-tac-toe/ui/pages/index.tsx
+++ b/tic-tac-toe/ui/pages/index.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import LoginComponent from "../components/dashboard/LoginComponent";
 import OpenGamesList from "../components/dashboard/OpenGameList";
@@ -9,6 +10,7 @@ import PageWrapper from "../components/nh/pageWrapper/PageWrapper";
 import calimeroSdk from "../utils/calimeroSdk";
 
 export default function Dashboard() {
+  const router = useRouter();
   const [logged, setLogged] = useState<boolean>(false);
   useEffect(() => {
     const loggedIn = calimeroSdk.isSignedIn();
@@ -18,5 +20,9 @@ export default function Dashboard() {
       setLogged(false);
     }
   });
-  return <PageWrapper />;
+  return (
+    <PageWrapper title={"PropUrl"} currentPage={router.pathname}>
+      <div>abc</div>
+    </PageWrapper>
+  );
 }


### PR DESCRIPTION
# feat: example NH navigation bar
 
## Summary:
Added NH side navigation bar to tictactoe calimero example.

## Test plan:

<img width="1505" alt="Screenshot 2022-12-21 at 13 40 17" src="https://user-images.githubusercontent.com/93442516/208908178-af4ccc73-4ad0-46d4-8532-e8d6615022f8.png">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added a test plan that prove my fix is effective or that my feature works
- [x] I squashed all commits and provided a meaningful commit message
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
