### PR TITLE
Using the calimero-sdk-rs for interaction with xsc connectors

### DIFF
--- a/tic-tac-toe/contracts/calimero-tictactoe/Cargo.lock
+++ b/tic-tac-toe/contracts/calimero-tictactoe/Cargo.lock
@@ -191,6 +191,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "calimero-sdk"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229adc21f68e0bfb6bbfc35beb0c83940164bb3fecfab1812a0300733fd4e972"
+dependencies = [
+ "calimero-sdk-macros",
+]
+
+[[package]]
+name = "calimero-sdk-macros"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13638cfbc4087496bddeac045e013c1a94c04b5add9da075a9b5d831e2065594"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1148,7 @@ dependencies = [
 name = "tic_tac_toe"
 version = "0.1.0"
 dependencies = [
+ "calimero-sdk",
  "near-sdk",
 ]
 

--- a/tic-tac-toe/contracts/calimero-tictactoe/Cargo.toml
+++ b/tic-tac-toe/contracts/calimero-tictactoe/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 near-sdk = "4.0.0"
+calimero-sdk = "0.0.1"
 
 [profile.release]
 codegen-units = 1

--- a/tic-tac-toe/contracts/calimero-tictactoe/deploy_calimero.sh
+++ b/tic-tac-toe/contracts/calimero-tictactoe/deploy_calimero.sh
@@ -5,16 +5,16 @@ if [ "$#" -ne 1 ]; then
 fi
 
 shard_id=$1
-destination_master_account="testnet"
+destination_master_account="$shard_id.calimero.testnet"
 
 near create-account \
   "tictactoe.$destination_master_account" \
   --masterAccount $destination_master_account \
-  --nodeUrl "https://api.development.calimero.network/api/v1/shards/$shard_id-calimero-testnet/neard-rpc/" \
+  --nodeUrl "https://api.dev.calimero.network/api/v1/shards/$shard_id-calimero-testnet/neard-rpc/" \
   --networkId "$1-calimero-testnet" && \
 near deploy \
   --accountId "tictactoe.$destination_master_account" \
   --initFunction new --initArgs {} \
   --wasmFile target/wasm32-unknown-unknown/release/tic_tac_toe.wasm \
-  --nodeUrl "https://api.development.calimero.network/api/v1/shards/$shard_id-calimero-testnet/neard-rpc/" \
+  --nodeUrl "https://api.dev.calimero.network/api/v1/shards/$shard_id-calimero-testnet/neard-rpc/" \
   --networkId "$1-calimero-testnet"

--- a/tic-tac-toe/contracts/calimero-tictactoe/src/lib.rs
+++ b/tic-tac-toe/contracts/calimero-tictactoe/src/lib.rs
@@ -6,6 +6,7 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{env, near_bindgen, require, AccountId, PanicOnDefault, Gas, Balance};
 use near_sdk::serde_json::{json, self};
+use calimero_sdk::{calimero_cross_shard_connector, calimero_cross_call_execute};
 
 #[derive(BorshDeserialize, BorshSerialize, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 #[serde(crate = "near_sdk::serde")]
@@ -40,13 +41,13 @@ pub struct TicTacToe {
     games: Vec<Game>,
 }
 
-const CROSS_SHARD_CALL_CONTRACT_ID: &str = "xsc_connector.pay14.calimero.testnet";
 const DESTINATION_CONTRACT_ID: &str = "tictactoe.igi.testnet"; // tictactoe on testnet
 const DESTINATION_CONTRACT_METHOD: &str = "game_ended";
 const DESTINATION_GAS: Gas = Gas(50_000_000_000_000);
 const DESTINATION_DEPOSIT: Balance = 0;
-const NO_DEPOSIT: Balance = 0;
 const CROSS_CALL_GAS: Gas = Gas(150_000_000_000_000);
+
+calimero_cross_shard_connector!("xsc_connector.lal89.calimero.testnet");
 
 #[near_bindgen]
 impl TicTacToe {
@@ -159,20 +160,17 @@ impl TicTacToe {
         }
 
         if selected_game.status != GameStatus::InProgress {
-            env::promise_return(env::promise_create(
-                AccountId::new_unchecked(CROSS_SHARD_CALL_CONTRACT_ID.to_string()
-            ),
-                "cross_call",
-                &serde_json::to_vec(&(
-                    DESTINATION_CONTRACT_ID, 
-                    DESTINATION_CONTRACT_METHOD, 
-                    json!({"game_id":game_id,"game":selected_game}).to_string(), 
-                    DESTINATION_GAS, 
-                    DESTINATION_DEPOSIT, 
-                    "callback_game_ended")).unwrap(),
-                NO_DEPOSIT,
-                CROSS_CALL_GAS,
-            ));
+            let args = json!({"game_id":game_id,"game":selected_game});
+
+            calimero_cross_call_execute!(
+                DESTINATION_CONTRACT_ID,
+                DESTINATION_CONTRACT_METHOD,
+                args,
+                DESTINATION_GAS,
+                DESTINATION_DEPOSIT,
+                "callback_game_ended",
+                CROSS_CALL_GAS
+            );
         }
 
         selected_game.status == GameStatus::InProgress 

--- a/tic-tac-toe/contracts/near-tictactoe/Cargo.lock
+++ b/tic-tac-toe/contracts/near-tictactoe/Cargo.lock
@@ -191,6 +191,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "calimero-sdk"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229adc21f68e0bfb6bbfc35beb0c83940164bb3fecfab1812a0300733fd4e972"
+dependencies = [
+ "calimero-sdk-macros",
+]
+
+[[package]]
+name = "calimero-sdk-macros"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13638cfbc4087496bddeac045e013c1a94c04b5add9da075a9b5d831e2065594"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1148,7 @@ dependencies = [
 name = "tic_tac_toe"
 version = "0.1.0"
 dependencies = [
+ "calimero-sdk",
  "near-sdk",
 ]
 

--- a/tic-tac-toe/contracts/near-tictactoe/Cargo.toml
+++ b/tic-tac-toe/contracts/near-tictactoe/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 near-sdk = "4.0.0"
+calimero-sdk = "0.0.1"
 
 [profile.release]
 codegen-units = 1

--- a/tic-tac-toe/contracts/near-tictactoe/src/lib.rs
+++ b/tic-tac-toe/contracts/near-tictactoe/src/lib.rs
@@ -7,6 +7,7 @@ use near_sdk::collections::{LookupMap, UnorderedSet};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{env, near_bindgen, require, AccountId, PanicOnDefault, Gas, Balance};
 use near_sdk::serde_json::{json, self};
+use calimero_sdk::{calimero_cross_shard_connector, calimero_cross_call_execute, calimero_expand};
 
 #[derive(BorshDeserialize, BorshSerialize, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 #[serde(crate = "near_sdk::serde")]
@@ -43,14 +44,15 @@ pub struct TicTacToe {
     player_awaiting_for_opponent: Option<AccountId>,
 }
 
-const CROSS_SHARD_CALL_CONTRACT_ID: &str = "xsc_connector.pay14.dev.calimero.testnet";
-const DESTINATION_CONTRACT_ID: &str = "tictactoe.testnet";
+const DESTINATION_CONTRACT_ID: &str = "tictactoe.lal89.calimero.testnet"; // tictactoe on calimero
 const DESTINATION_CONTRACT_METHOD: &str = "start_game";
 const DESTINATION_GAS: Gas = Gas(50_000_000_000_000);
 const DESTINATION_DEPOSIT: Balance = 0;
-const NO_DEPOSIT: Balance = 0;
 const CROSS_CALL_GAS: Gas = Gas(100_000_000_000_000);
 
+calimero_cross_shard_connector!("xsc_connector.lal89.dev.calimero.testnet");
+
+#[calimero_expand]
 #[near_bindgen]
 impl TicTacToe {
     #[init]
@@ -79,35 +81,25 @@ impl TicTacToe {
 
             self.player_awaiting_for_opponent = None;
 
-            env::promise_return(env::promise_create(
-                AccountId::new_unchecked(CROSS_SHARD_CALL_CONTRACT_ID.to_string()
-            ),
-                "cross_call",
-                &serde_json::to_vec(&(
-                    DESTINATION_CONTRACT_ID, 
-                    DESTINATION_CONTRACT_METHOD, 
-                    json!({"player_a":first_player,"player_b":env::predecessor_account_id()}).to_string(), 
-                    DESTINATION_GAS, 
-                    DESTINATION_DEPOSIT, 
-                    "game_started")).unwrap(),
-                NO_DEPOSIT,
-                CROSS_CALL_GAS,
-            ));
+            let args = json!({"player_a":first_player,"player_b":env::predecessor_account_id()});
+
+            calimero_cross_call_execute!(
+                DESTINATION_CONTRACT_ID,
+                DESTINATION_CONTRACT_METHOD,
+                args,
+                DESTINATION_GAS,
+                DESTINATION_DEPOSIT,
+                "game_started",
+                CROSS_CALL_GAS
+            );
         } else {
             self.player_awaiting_for_opponent = Some(env::predecessor_account_id());
         }
     }
 
-    pub fn game_started(&mut self, response: Option<Vec<u8>>) {
-        require!(env::predecessor_account_id().to_string() == CROSS_SHARD_CALL_CONTRACT_ID);
-        if response.is_none() {
-            // Call failed
-            env::log_str(&format!("Got empty response!"));
-        } else {
-            let game_id: usize = near_sdk::serde_json::from_slice::<usize>(&response.unwrap()).unwrap();
-            env::log_str(&format!("GOT THE CALLBACK WITH EXEC RESULT {}", game_id));
-            self.all_games.insert(&game_id);
-        }
+    #[calimero_receive_response]
+    pub fn game_started(&mut self, game_id: usize) {
+        self.all_games.insert(&game_id);
     }
 
     pub fn game_ended(&mut self, game_id: usize, game: Game) {


### PR DESCRIPTION
Test plan:
Verified tictactoe game can be started from NEAR on Calimero and callback is received on NEAR with the new macro lib that simplifies boilerplate code.

Verified game_started callback executed on NEAR after execution on Calimero: https://explorer.testnet.near.org/transactions/G9UV4QoJGcmcWy4G1rCdmjm11xYKyacFnhuWypvNhpqG